### PR TITLE
Fix for ie11

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,8 +49,8 @@
   ],
   "dependencies": {
     "@gmod/binary-parser": "^1.3.2",
-    "lru-cache": "^4.1.3",
-    "util.promisify": "^1.0.0"
+    "es6-promisify": "^6.0.1",
+    "quick-lru": "^2.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",

--- a/src/localFile.js
+++ b/src/localFile.js
@@ -1,4 +1,4 @@
-const promisify = require('util.promisify')
+const {promisify} = require('es6-promisify')
 
 // don't load fs native module if running in webpacked code
 // eslint-disable-next-line camelcase

--- a/src/localFile.js
+++ b/src/localFile.js
@@ -1,4 +1,4 @@
-const {promisify} = require('es6-promisify')
+const { promisify } = require('es6-promisify')
 
 // don't load fs native module if running in webpacked code
 // eslint-disable-next-line camelcase

--- a/src/tribbleIndexedFile.js
+++ b/src/tribbleIndexedFile.js
@@ -1,4 +1,4 @@
-const LRU = require('lru-cache')
+const LRU = require('quick-lru')
 const LocalFile = require('./localFile')
 const read = require('./tribble')
 
@@ -62,9 +62,8 @@ class TribbleIndexedFile {
     this.chunkSizeLimit = chunkSizeLimit
     this.yieldLimit = yieldLimit
     this.renameRefSeqCallback = renameRefSeqs
-    this.blockCache = LRU({
-      max: Math.floor(blockCacheSize / (1 << 16)),
-      length: () => 1,
+    this.blockCache = new LRU({
+      maxSize: Math.floor(blockCacheSize / (1 << 16)),
     })
   }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,7 +1,7 @@
 import fs from 'fs'
 import { read } from '../src'
 
-const {promisify} = require('es6-promisify')
+const { promisify } = require('es6-promisify')
 
 const readFile = promisify(fs.readFile)
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,7 +1,7 @@
 import fs from 'fs'
 import { read } from '../src'
 
-const promisify = require('util.promisify')
+const {promisify} = require('es6-promisify')
 
 const readFile = promisify(fs.readFile)
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2254,6 +2254,11 @@ es-to-primitive@^1.1.1:
     is-date-object "^1.0.1"
     is-symbol "^1.0.1"
 
+es6-promisify@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/es6-promisify/-/es6-promisify-6.0.1.tgz#6edaa45f3bd570ffe08febce66f7116be4b1cdb6"
+  integrity sha512-J3ZkwbEnnO+fGAKrjVpeUAnZshAdfZvbhQpqfIH9kSAspReRC4nJnu8ewm55b4y9ElyeuhCTzJD0XiH8Tsbhlw==
+
 escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
@@ -4406,7 +4411,7 @@ lowercase-keys@^1.0.0:
   resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-1.0.1.tgz#6f9e30b47084d971a7c820ff15a6c5167b74c26f"
   integrity sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==
 
-lru-cache@^4.0.1, lru-cache@^4.1.3:
+lru-cache@^4.0.1:
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.3.tgz#a1175cf3496dfc8436c156c334b4955992bce69c"
   integrity sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==
@@ -5476,6 +5481,11 @@ query-string@^5.0.1:
     decode-uri-component "^0.2.0"
     object-assign "^4.1.0"
     strict-uri-encode "^1.0.0"
+
+quick-lru@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-2.0.0.tgz#32b017b28d1784631c8ab0a1ed2978e094dbe181"
+  integrity sha512-DqOtZziv7lDjEyuqyVQacRciAwMCEjTNrLYCHYEIIgjcE/tLEpBF82hiDIwCjRnEL9/hY2GJxA0T8ZvYvVVSSA==
 
 randomatic@^3.0.0:
   version "3.1.0"


### PR DESCRIPTION
This changes to use quick-lru which aids IE11 compatibility because lru-cache uses Object.defineProperty on length which seems un-babel-ifiable

The util.promisify also can end up doing Object.defineProperty on the length property too so es6-promisify is used